### PR TITLE
Version 2.3.7.8 - Auto updating updatetAt field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import play.PlayScala
 
 name := "norm"
 
-version := "2.3.7.7"
+version := "2.3.7.8"
 
 scalaVersion := "2.11.7"
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>norm</groupId>
     <artifactId>norm_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.7.7</version>
+    <version>2.3.7.8</version>
 
     <name>Norm</name>
     <url>https://github.com/99taxis/norm</url>

--- a/src/main/scala/norm/norm.scala
+++ b/src/main/scala/norm/norm.scala
@@ -294,7 +294,7 @@ abstract class Norm[T: TypeTag](tableNameOpt: Option[String] = None, saveUpdateD
     val idParam: NamedParameter = (NormProcessor.id -> idValue)
     val updateProperties: Seq[NamedParameter] = if (properties.isEmpty) allProperties else NormProcessor.toNamedParameterWithUpdatedAt(properties)
     val updateValues: Seq[NamedParameter] =
-      if (saveUpdateDate && !updateProperties.exists(_.name = NormProcessor.updatedDate)) {
+      if (saveUpdateDate && !updateProperties.exists(_.name == NormProcessor.updatedDate)) {
         val updateParam: NamedParameter = (NormProcessor.updatedDate -> DateTime.now())
         updateProperties ++ Seq(idParam, updateParam)
       } else {
@@ -422,7 +422,7 @@ abstract class NormCompanion[T: TypeTag](tableNameOpt: Option[String] = None, sa
     val idParam: NamedParameter = (NormProcessor.id -> id)
     val updateProperties: Seq[NamedParameter] = NormProcessor.toNamedParameterWithUpdatedAt(properties)
     val updateValues: Seq[NamedParameter] =
-      if (saveUpdateDate && !updateProperties.exists(_.name = NormProcessor.updatedDate)) {
+      if (saveUpdateDate && !updateProperties.exists(_.name == NormProcessor.updatedDate)) {
         val updateParam: NamedParameter = (NormProcessor.updatedDate -> DateTime.now())
         updateProperties ++ Seq(idParam, updateParam)
       } else {


### PR DESCRIPTION
In previous versions, the `updatedA`t field isn't updated automatically. In this new version, you can set the flag `saveUpdateDate` when extending `Norm` and `NormCompanion` classes and that field will be saved in every update action.